### PR TITLE
fix(worker-status): detect runner crash before stale result.env check

### DIFF
--- a/tools/bin/agent-project-worker-status
+++ b/tools/bin/agent-project-worker-status
@@ -87,6 +87,25 @@ if [[ "$status" == "UNKNOWN" && -f "$output_file" ]]; then
   fi
 fi
 
+if [[ "$status" == "UNKNOWN" && -n "$runner_state" ]]; then
+  case "$runner_state" in
+    running|waiting-auth-refresh|switching-account)
+      # Tmux session is gone and runner never reached a terminal state.
+      # This detects crashes where the worker process died before updating
+      # runner.env or writing an exit marker.
+      # Check BEFORE stale result.env to avoid false SUCCEEDED when a prior
+      # cycle's result.env happens to exist.
+      status="FAILED"
+      if [[ -z "$failure_reason" ]]; then
+        failure_reason="runner-aborted-before-completion"
+      fi
+      if [[ -z "$exit_code" && -n "$last_exit_code" ]]; then
+        exit_code="$last_exit_code"
+      fi
+      ;;
+  esac
+fi
+
 if [[ "$status" == "UNKNOWN" && -f "$result_file" ]]; then
   # A worker that managed to persist result.env already completed its contract,
   # even if the tmux session disappeared before the exit marker was flushed.
@@ -99,20 +118,6 @@ if [[ "$status" == "UNKNOWN" && -f "$output_file" ]]; then
     status="FAILED"
     failure_reason="usage-limit"
   fi
-fi
-
-if [[ "$status" == "UNKNOWN" && -n "$runner_state" ]]; then
-  case "$runner_state" in
-    running|waiting-auth-refresh|switching-account)
-      status="FAILED"
-      if [[ -z "$failure_reason" ]]; then
-        failure_reason="runner-aborted-before-completion"
-      fi
-      if [[ -z "$exit_code" && -n "$last_exit_code" ]]; then
-        exit_code="$last_exit_code"
-      fi
-      ;;
-  esac
 fi
 
 printf 'SESSION=%s\n' "$session"

--- a/tools/tests/test-agent-project-worker-status-detects-crash.sh
+++ b/tools/tests/test-agent-project-worker-status-detects-crash.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FLOW_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORKER_STATUS_TOOL="${FLOW_ROOT}/tools/bin/agent-project-worker-status"
+
+tmpdir="$(mktemp -d)"
+cleanup() { rm -rf "${tmpdir}"; }
+trap cleanup EXIT
+
+session="test-crash-1"
+runs_root="${tmpdir}/runs"
+session_log="${runs_root}/${session}/${session}.log"
+runner_state_file="${runs_root}/${session}/runner.env"
+result_file="${runs_root}/${session}/result.env"
+run_env="${runs_root}/${session}/run.env"
+
+mkdir -p "${runs_root}/${session}"
+
+# Minimal run.env
+cat >"$run_env" <<EOF
+SESSION=${session}
+TASK_KIND=issue
+TASK_ID=99
+EOF
+
+# Helper to assert STATUS value
+assert_status() {
+  local expected="${1:?expected status required}"
+  local actual
+  actual="$(bash "${WORKER_STATUS_TOOL}" --runs-root "${runs_root}" --session "${session}" | awk -F= '/^STATUS=/{print $2}')"
+  if [[ "$actual" != "$expected" ]]; then
+    echo "FAIL: expected STATUS=${expected} but got STATUS=${actual}" >&2
+    return 1
+  fi
+  printf .
+}
+
+assert_failure_reason() {
+  local expected="${1:?expected reason required}"
+  local actual
+  actual="$(bash "${WORKER_STATUS_TOOL}" --runs-root "${runs_root}" --session "${session}" | awk -F= '/^FAILURE_REASON=/{print $2}')"
+  if [[ "$actual" != "$expected" ]]; then
+    echo "FAIL: expected FAILURE_REASON=${expected} but got FAILURE_REASON=${actual}" >&2
+    return 1
+  fi
+  printf .
+}
+
+# ============================================================
+# Test 1: Runner still running, tmux gone → FAILED (crash)
+# This is the primary bug: without the fix, a stale result.env
+# from a prior cycle would cause SUCCEEDED instead.
+# ============================================================
+
+# Simulate a previous cycle that wrote result.env
+cat >"$result_file" <<'EOF'
+OUTCOME=implemented
+ACTION=host-publish-issue-pr
+EOF
+
+# Simulate runner that crashed mid-cycle (still marked running).
+# When LAST_FAILURE_REASON is already set, worker-status preserves it;
+# when empty it falls back to runner-aborted-before-completion.
+cat >"$runner_state_file" <<'EOF'
+RUNNER_STATE=running
+THREAD_ID=some-thread
+ATTEMPT=1
+RESUME_COUNT=0
+LAST_EXIT_CODE=1
+LAST_FAILURE_REASON=""
+LAST_TRIGGER_REASON=schedule
+UPDATED_AT=2025-01-01T00:00:00Z
+EOF
+
+# No exit marker in log
+: >"$session_log"
+
+assert_status "FAILED"
+assert_failure_reason "runner-aborted-before-completion"
+
+# ============================================================
+# Test 2: Runner crashed with waiting-auth-refresh → FAILED
+# ============================================================
+
+cat >"$runner_state_file" <<'EOF'
+RUNNER_STATE=waiting-auth-refresh
+THREAD_ID=auth-thread
+ATTEMPT=2
+RESUME_COUNT=0
+LAST_EXIT_CODE=
+LAST_FAILURE_REASON=""
+LAST_TRIGGER_REASON=schedule
+UPDATED_AT=2025-01-01T00:00:00Z
+EOF
+
+assert_status "FAILED"
+assert_failure_reason "runner-aborted-before-completion"
+
+# ============================================================
+# Test 3: Runner crashed with switching-account → FAILED
+# ============================================================
+
+cat >"$runner_state_file" <<'EOF'
+RUNNER_STATE=switching-account
+THREAD_ID=switch-thread
+ATTEMPT=1
+RESUME_COUNT=0
+LAST_EXIT_CODE=0
+LAST_FAILURE_REASON=""
+LAST_TRIGGER_REASON=schedule
+UPDATED_AT=2025-01-01T00:00:00Z
+EOF
+
+assert_status "FAILED"
+
+# ============================================================
+# Test 4: Runner succeeded (normal path unchanged)
+# ============================================================
+
+# Remove stale state
+rm -f "$result_file"
+
+cat >"$runner_state_file" <<'EOF'
+RUNNER_STATE=succeeded
+THREAD_ID=ok-thread
+ATTEMPT=1
+RESUME_COUNT=0
+LAST_EXIT_CODE=0
+LAST_FAILURE_REASON=""
+LAST_TRIGGER_REASON=schedule
+UPDATED_AT=2025-01-01T00:00:00Z
+EOF
+
+assert_status "SUCCEEDED"
+
+# ============================================================
+# Test 5: Runner failed (normal path unchanged)
+# ============================================================
+
+cat >"$runner_state_file" <<'EOF'
+RUNNER_STATE=failed
+THREAD_ID=fail-thread
+ATTEMPT=1
+RESUME_COUNT=0
+LAST_EXIT_CODE=42
+LAST_FAILURE_REASON=syntax-error
+LAST_TRIGGER_REASON=schedule
+UPDATED_AT=2025-01-01T00:00:00Z
+EOF
+
+assert_status "FAILED"
+assert_failure_reason "syntax-error"
+
+# ============================================================
+# Test 6: Unknown state with stale result.env and no runner crash
+# → SUCCEEDED via result.env (still works for valid completions)
+# ============================================================
+
+rm -f "$runner_state_file"
+: >"$session_log"
+
+cat >"$result_file" <<'EOF'
+OUTCOME=implemented
+ACTION=host-publish-issue-pr
+EOF
+
+assert_status "SUCCEEDED"
+out="$(bash "${WORKER_STATUS_TOOL}" --runs-root "${runs_root}" --session "${session}")"
+if ! grep -q 'RESULT_ONLY_COMPLETION=yes' <<<"$out"; then
+  echo "FAIL: expected RESULT_ONLY_COMPLETION=yes" >&2
+  exit 1
+fi
+
+echo ""
+echo "worker-status crash detection tests passed"


### PR DESCRIPTION
## Summary

- Implements #3: Keep open: improve scheduler resilience and dashboard observability
- Host-side publication for session `agent-control-plane-issue-3`
- Commit: `5972736548d30305b4073a02b03e16c0d2e7ae88`

## Verification

- Local verification was executed by the sandboxed issue worker in its isolated worktree.
- Detailed command output is available in the run artifacts for `agent-control-plane-issue-3`.
