### PR TITLE
Exclude legacy prompt template from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -15,3 +15,4 @@ tools/vendor/codex-quota/README.md
 tools/dashboard/__pycache__/
 tools/tests/__pycache__/
 *.pyc
+tools/templates/legacy/

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "tools/dashboard/server.py",
     "tools/dashboard/styles.css",
     "tools/templates",
+    "!tools/templates/legacy/",
     "tools/vendor/codex-quota/LICENSE",
     "tools/vendor/codex-quota/codex-quota.js",
     "tools/vendor/codex-quota/lib",

--- a/tools/tests/test-package-tarball-surface.sh
+++ b/tools/tests/test-package-tarball-surface.sh
@@ -42,6 +42,7 @@ for (const forbiddenPath of [
   "tools/bin/audit-retained-worktrees.sh",
   "tools/bin/check-skill-contracts.sh",
   "bin/audit-issue-routing.sh",
+  "tools/templates/legacy/issue-prompt-template-pre-slim.md",
 ]) {
   if (paths.has(forbiddenPath)) {
     fail(`forbidden tarball path present: ${forbiddenPath}`);


### PR DESCRIPTION
## Summary

- Implements #1: Keep open: improve package and release trust surface
- Host-side publication for session `agent-control-plane-issue-1`
- Commit: `88a859416691caf20fb545120a777d8e54de6acd`

## Verification

- Local verification was executed by the sandboxed issue worker in its isolated worktree.
- Detailed command output is available in the run artifacts for `agent-control-plane-issue-1`.
