### PR TITLE
Suppress macOS-only launchd line in dry-run on non-macOS

### DIFF
--- a/npm/bin/agent-control-plane.js
+++ b/npm/bin/agent-control-plane.js
@@ -1341,7 +1341,9 @@ function printSetupDryRunPlan(context, config, plan) {
   }
   console.log(`- GitHub auth step: ${plan.githubAuthAction.status}${plan.githubAuthAction.reason ? ` (${plan.githubAuthAction.reason})` : ""}`);
   console.log(`- runtime start: ${plan.runtimeStartAction.status}${plan.runtimeStartAction.reason ? ` (${plan.runtimeStartAction.reason})` : ""}`);
-  console.log(`- launchd install: ${plan.launchdAction.status}${plan.launchdAction.reason ? ` (${plan.launchdAction.reason})` : ""}`);
+  if (process.platform === "darwin") {
+    console.log(`- launchd install: ${plan.launchdAction.status}${plan.launchdAction.reason ? ` (${plan.launchdAction.reason})` : ""}`);
+  }
 }
 
 function buildSetupResultPayload(params) {


### PR DESCRIPTION
## Summary

- Implements #2: Keep open: improve onboarding and cross-platform setup resilience
- Host-side publication for session `agent-control-plane-issue-2`
- Commit: `2eafd7dbc22a8aae2789844465def7d0232d3782`

## Verification

- Local verification was executed by the sandboxed issue worker in its isolated worktree.
- Detailed command output is available in the run artifacts for `agent-control-plane-issue-2`.
