### PR TITLE
Exclude render-dashboard-snapshot.py stub from npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -16,3 +16,4 @@ tools/dashboard/__pycache__/
 tools/tests/__pycache__/
 *.pyc
 tools/templates/legacy/
+tools/bin/render-dashboard-snapshot.py

--- a/SKILL.md
+++ b/SKILL.md
@@ -22,7 +22,7 @@ external profile registry, not inside this repository.
 - installed project profiles in `~/.agent-runtime/control-plane/profiles/*/control-plane.yaml`
 - installed profile notes in `~/.agent-runtime/control-plane/profiles/*/README.md`
 - workflow catalog in `assets/workflow-catalog.json`
-- worker dashboard in `tools/dashboard/` with launchers in `tools/bin/render-dashboard-snapshot.py`
+- worker dashboard in `tools/dashboard/` with launcher at `tools/dashboard/dashboard_snapshot.py`
   and `tools/bin/serve-dashboard.sh`
 - dashboard autostart helpers in `tools/bin/dashboard-launchd-bootstrap.sh` and
   `tools/bin/install-dashboard-launchd.sh`

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "tools/bin",
     "!tools/bin/audit-*.sh",
     "!tools/bin/check-skill-contracts.sh",
+    "!tools/bin/render-dashboard-snapshot.py",
     "tools/dashboard/app.js",
     "tools/dashboard/dashboard_snapshot.py",
     "tools/dashboard/index.html",

--- a/references/commands.md
+++ b/references/commands.md
@@ -85,7 +85,7 @@ tools/bin/uninstall-project-launchd.sh --profile-id <id>
 tools/bin/project-remove.sh --profile-id <id>
 tools/bin/project-remove.sh --profile-id <id> --purge-paths
 tools/bin/sync-shared-agent-home.sh
-python3 tools/bin/render-dashboard-snapshot.py --pretty
+python3 tools/dashboard/dashboard_snapshot.py --pretty
 bash tools/bin/serve-dashboard.sh --host 127.0.0.1 --port 8765
 bash tools/bin/install-dashboard-launchd.sh --host 127.0.0.1 --port 8765
 ```
@@ -97,7 +97,7 @@ prompts live under `tools/templates/`.
 ## Dashboard
 
 ```bash
-python3 tools/bin/render-dashboard-snapshot.py --pretty
+python3 tools/dashboard/dashboard_snapshot.py --pretty
 bash tools/bin/serve-dashboard.sh --host 127.0.0.1 --port 8765
 bash tools/bin/install-dashboard-launchd.sh --host 127.0.0.1 --port 8765
 ```

--- a/references/control-plane-map.md
+++ b/references/control-plane-map.md
@@ -64,7 +64,7 @@ roots, labels, worker preferences, prompts, and project-specific guardrails.
   before scheduler use.
 - `tools/bin/test-smoke.sh`
   Runs the main shared-package smoke gates in one operator-facing command.
-- `tools/bin/render-dashboard-snapshot.py`
+- `tools/dashboard/dashboard_snapshot.py`
   Emits a JSON snapshot of active runs, resident controllers, cooldown state,
   queue depth, and scheduled issues across installed profiles.
 - `tools/bin/serve-dashboard.sh`

--- a/tools/tests/test-package-tarball-surface.sh
+++ b/tools/tests/test-package-tarball-surface.sh
@@ -43,6 +43,7 @@ for (const forbiddenPath of [
   "tools/bin/check-skill-contracts.sh",
   "bin/audit-issue-routing.sh",
   "tools/templates/legacy/issue-prompt-template-pre-slim.md",
+  "tools/bin/render-dashboard-snapshot.py",
 ]) {
   if (paths.has(forbiddenPath)) {
     fail(`forbidden tarball path present: ${forbiddenPath}`);
@@ -73,6 +74,11 @@ const result = {
 };
 
 console.log(JSON.stringify(result));
+
+// Compressed-size budget guard: fail if the tarball creeps above 400 KB.
+if (pack.size > 400 * 1024) {
+  fail(`tarball compressed size ${Math.round(pack.size / 1024)} KB exceeds 400 KB budget`);
+}
 NODE
 
 TMP_PACKAGE_JSON=$(mktemp)


### PR DESCRIPTION
## Summary

- Implements #1: Keep open: improve package and release trust surface
- Host-side publication for session `agent-control-plane-issue-1`
- Commit: `50484025a0c34b84102da377ea42c44a6816348a`

## Verification

- Local verification was executed by the sandboxed issue worker in its isolated worktree.
- Detailed command output is available in the run artifacts for `agent-control-plane-issue-1`.
