### PR TITLE
Show claimed issues in dashboard

### DIFF
--- a/tools/dashboard/app.js
+++ b/tools/dashboard/app.js
@@ -314,6 +314,16 @@ function renderProfile(profile) {
     "No pending leased issues.",
   );
 
+  const claimsTable = renderTable(
+    [
+      { label: "Issue", key: "issue_id" },
+      { label: "Session", render: (row) => row.session ? `<div class="mono">${row.session}</div>` : "n/a" },
+      { label: "Updated", render: (row) => row.updated_at ? `${relativeTime(row.updated_at)}<div class="muted">${row.updated_at}</div>` : "n/a" },
+    ],
+    profile.issue_queue.claims || [],
+    "No claimed issues.",
+  );
+
   const codexRotationPanel =
     profile.coding_worker === "codex"
       ? `
@@ -383,6 +393,10 @@ function renderProfile(profile) {
         <section class="panel half">
           <h3>Pending Issue Queue</h3>
           ${queueTable}
+        </section>
+        <section class="panel half">
+          <h3>Claimed Issues</h3>
+          ${claimsTable}
         </section>
       </section>
     </article>

--- a/tools/tests/test-control-plane-dashboard-runtime-smoke.sh
+++ b/tools/tests/test-control-plane-dashboard-runtime-smoke.sh
@@ -47,6 +47,7 @@ mkdir -p \
   "${state_root}/resident-workers/issues/${recurring_worker_key}" \
   "${state_root}/resident-workers/issues/${scheduled_worker_key}" \
   "${state_root}/resident-workers/issue-queue/pending" \
+  "${state_root}/resident-workers/issue-queue/claims" \
   "${state_root}/retries/providers" \
   "${state_root}/scheduled-issues"
 
@@ -258,6 +259,12 @@ SESSION=demo-issue-6
 UPDATED_AT=2026-03-27T11:13:30Z
 EOF
 
+cat >"${state_root}/resident-workers/issue-queue/claims/issue-7.env" <<'EOF'
+ISSUE_ID=7
+SESSION=demo-issue-7
+UPDATED_AT=2026-03-27T11:14:00Z
+EOF
+
 snapshot_file="${tmpdir}/snapshot.json"
 api_snapshot_file="${tmpdir}/api-snapshot.json"
 
@@ -314,6 +321,7 @@ assert profile["counts"]["blocked_runs"] == 0
 assert profile["counts"]["live_resident_controllers"] == 1
 assert profile["counts"]["resident_workers"] == 2
 assert profile["counts"]["queued_issues"] == 1
+assert profile["counts"]["claimed_issues"] == 1
 assert profile["counts"]["provider_cooldowns"] == 1
 assert profile["counts"]["scheduled_issues"] == 1
 
@@ -333,6 +341,12 @@ assert controller["provider_wait_total_seconds"] == 90
 workers = {item["key"]: item for item in profile["resident_workers"]}
 assert workers["issue-lane-recurring-general-openclaw-safe"]["last_action"] == "host-publish-issue-pr"
 assert workers["issue-lane-scheduled-1800-openclaw-safe"]["last_action"] == "host-comment-scheduled-report"
+
+queue = profile["issue_queue"]
+assert len(queue["pending"]) == 1
+assert queue["pending"][0]["issue_id"] == "6"
+assert len(queue["claims"]) == 1
+assert queue["claims"][0]["issue_id"] == "7"
 
 assert api_profile["counts"]["implemented_runs"] == 1
 assert api_profile["counts"]["reported_runs"] == 1


### PR DESCRIPTION
## Summary

- Implements #3: Keep open: improve scheduler resilience and dashboard observability
- Host-side publication for session `agent-control-plane-issue-3`
- Commit: `7526c6fa84d31d795056667425d591e00bbda284`

## Verification

- Local verification was executed by the sandboxed issue worker in its isolated worktree.
- Detailed command output is available in the run artifacts for `agent-control-plane-issue-3`.
