### PR TITLE
Add tarball-level smoke test to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -111,6 +111,9 @@ jobs:
       - name: Check package tarball
         run: npm pack --dry-run
 
+      - name: Verify package smoke command
+        run: bash tools/tests/test-package-smoke-command.sh
+
       - name: Publish to npm
         shell: bash
         run: |


### PR DESCRIPTION
## Summary

- Implements #1: Keep open: improve package and release trust surface
- Host-side publication for session `agent-control-plane-issue-1`
- Commit: `b0889c3ba75f26d591d55e3df4667b46ace93588`

## Verification

- Local verification was executed by the sandboxed issue worker in its isolated worktree.
- Detailed command output is available in the run artifacts for `agent-control-plane-issue-1`.
