### PR TITLE
Show gh auth login preview in setup --dry-run plan

### DIFF
--- a/npm/bin/agent-control-plane.js
+++ b/npm/bin/agent-control-plane.js
@@ -1355,6 +1355,9 @@ function printSetupDryRunPlan(context, config, plan) {
     console.log(`  command preview: ${plan.workerInstallPlan.commands.map(formatCommand).join(" && ")}`);
   }
   console.log(`- GitHub auth step: ${plan.githubAuthAction.status}${plan.githubAuthAction.reason ? ` (${plan.githubAuthAction.reason})` : ""}`);
+  if (plan.githubAuthAction.status !== "not-needed") {
+    console.log(`  command preview: gh auth login`);
+  }
   console.log(`- runtime start: ${plan.runtimeStartAction.status}${plan.runtimeStartAction.reason ? ` (${plan.runtimeStartAction.reason})` : ""}`);
   if (process.platform === "darwin") {
     console.log(`- launchd install: ${plan.launchdAction.status}${plan.launchdAction.reason ? ` (${plan.launchdAction.reason})` : ""}`);


### PR DESCRIPTION
## Summary

- Implements #2: Keep open: improve onboarding and cross-platform setup resilience
- Host-side publication for session `agent-control-plane-issue-2`
- Commit: `5631638dee580b237bf0e945aed3e1814b381c04`

## Verification

- Local verification was executed by the sandboxed issue worker in its isolated worktree.
- Detailed command output is available in the run artifacts for `agent-control-plane-issue-2`.
