### PR TITLE
Add zypper (openSUSE/SLES) package manager support to setup dependency auto-install

### DIFF
--- a/npm/bin/agent-control-plane.js
+++ b/npm/bin/agent-control-plane.js
@@ -590,6 +590,9 @@ function detectPackageManager() {
   if (commandExists("pacman")) {
     return { name: "pacman" };
   }
+  if (commandExists("zypper")) {
+    return { name: "zypper" };
+  }
   return null;
 }
 
@@ -679,6 +682,9 @@ function buildDependencyInstallPlan(missingTools) {
       break;
     case "pacman":
       commands.push([...prefix, "pacman", "-Sy", "--noconfirm", ...packages]);
+      break;
+    case "zypper":
+      commands.push([...prefix, "zypper", "install", "-y", ...packages]);
       break;
     default:
       return null;


### PR DESCRIPTION
## Summary

- Implements #2: Keep open: improve onboarding and cross-platform setup resilience
- Host-side publication for session `agent-control-plane-issue-2`
- Commit: `04a58cc098ae2430c646bdf657e7a9f131d55492`

## Verification

- Local verification was executed by the sandboxed issue worker in its isolated worktree.
- Detailed command output is available in the run artifacts for `agent-control-plane-issue-2`.
