### PR TITLE
test: assert packaged entrypoints remain executable

### DIFF
--- a/tools/tests/test-package-tarball-surface.sh
+++ b/tools/tests/test-package-tarball-surface.sh
@@ -24,6 +24,7 @@ const fs = require("fs");
 const reportPath = process.argv[2];
 const pack = JSON.parse(fs.readFileSync(reportPath, "utf8"))[0];
 const paths = new Set((pack.files || []).map((entry) => entry.path));
+const entriesByPath = new Map((pack.files || []).map((entry) => [entry.path, entry]));
 
 function fail(message) {
   console.error(message);
@@ -63,6 +64,21 @@ for (const requiredPath of [
 ]) {
   if (!paths.has(requiredPath)) {
     fail(`required tarball path missing: ${requiredPath}`);
+  }
+}
+
+for (const executablePath of [
+  "bin/agent-control-plane",
+  "bin/issue-resource-class.sh",
+  "bin/label-follow-up-issues.sh",
+  "bin/pr-risk.sh",
+  "bin/sync-pr-labels.sh",
+  "npm/bin/agent-control-plane.js",
+  "tools/bin/test-smoke.sh",
+]) {
+  const entry = entriesByPath.get(executablePath);
+  if (!entry || (entry.mode & 0o111) === 0) {
+    fail(`required executable tarball path missing or non-executable: ${executablePath}`);
   }
 }
 


### PR DESCRIPTION
## Summary

- Implements #1: Keep open: improve package and release trust surface
- Host-side publication for session `agent-control-plane-issue-1`
- Commit: `c8155b1deb12a61b6b9376045904d10b23a4334f`

## Verification

- Local verification was executed by the sandboxed issue worker in its isolated worktree.
- Detailed command output is available in the run artifacts for `agent-control-plane-issue-1`.
