### PR TITLE
feat(dashboard): surface queue queueing and lane metadata

### DIFF
--- a/tools/dashboard/app.js
+++ b/tools/dashboard/app.js
@@ -283,6 +283,7 @@ function renderProfile(profile) {
     [
       { label: "Issue", key: "issue_id" },
       { label: "State", render: renderControllerState },
+      { label: "Lane", render: (row) => `${row.lane_kind || "n/a"} / ${row.lane_value || "n/a"}` },
       { label: "Reason", render: (row) => row.reason || "n/a" },
       { label: "Provider", render: (row) => `${row.provider_backend || "n/a"} ${row.provider_model || ""}`.trim() },
       { label: "Failover", render: (row) => `${row.provider_failover_count} failovers / ${row.provider_switch_count} switches` },
@@ -323,6 +324,7 @@ function renderProfile(profile) {
       { label: "Scope", key: "scope" },
       { label: "Worker", key: "coding_worker" },
       { label: "Issue", render: (row) => row.issue_id || "n/a" },
+      { label: "Lane", render: (row) => `${row.resident_lane_kind || "n/a"} / ${row.resident_lane_value || "n/a"}` },
       { label: "Tasks", key: "task_count" },
       { label: "Last status", render: (row) => row.last_status || "n/a" },
       { label: "Last started", render: (row) => row.last_started_at ? `${relativeTime(row.last_started_at)}<div class="muted">${row.last_started_at}</div>` : "n/a" },
@@ -358,6 +360,7 @@ function renderProfile(profile) {
     [
       { label: "Issue", key: "issue_id" },
       { label: "Session", render: (row) => row.session ? `<div class="mono">${row.session}</div>` : "n/a" },
+      { label: "Queued by", key: "queued_by" },
       { label: "Updated", render: (row) => row.updated_at ? `${relativeTime(row.updated_at)}<div class="muted">${row.updated_at}</div>` : "n/a" },
     ],
     profile.issue_queue.pending,
@@ -368,6 +371,7 @@ function renderProfile(profile) {
     [
       { label: "Issue", key: "issue_id" },
       { label: "Session", render: (row) => row.session ? `<div class="mono">${row.session}</div>` : "n/a" },
+      { label: "Claimed by", key: "claimer" },
       { label: "Updated", render: (row) => row.updated_at ? `${relativeTime(row.updated_at)}<div class="muted">${row.updated_at}</div>` : "n/a" },
     ],
     profile.issue_queue.claims || [],

--- a/tools/dashboard/dashboard_snapshot.py
+++ b/tools/dashboard/dashboard_snapshot.py
@@ -493,6 +493,13 @@ def collect_resident_workers(state_root: Path) -> list[dict[str, Any]]:
                 "last_action": env.get("LAST_ACTION", ""),
                 "last_failure_reason": env.get("LAST_FAILURE_REASON", ""),
                 "worktree": env.get("WORKTREE", ""),
+                "resident_lane_kind": env.get("RESIDENT_LANE_KIND", ""),
+                "resident_lane_value": env.get("RESIDENT_LANE_VALUE", ""),
+                "resident_lane": (
+                    f"{env.get('RESIDENT_LANE_KIND', '')}/{env.get('RESIDENT_LANE_VALUE', '')}"
+                    if env.get("RESIDENT_LANE_KIND", "") and env.get("RESIDENT_LANE_VALUE", "")
+                    else ""
+                ),
                 "metadata_file": str(path),
             }
         )
@@ -707,15 +714,33 @@ def collect_issue_queue(state_root: Path) -> dict[str, list[dict[str, Any]]]:
         items: list[dict[str, Any]] = []
         for path in sorted(root.glob("*.env"), key=lambda item: item.stat().st_mtime, reverse=True):
             env = read_env_file(path)
-            items.append(
-                {
-                    "issue_id": env.get("ISSUE_ID", path.stem.removeprefix("issue-")),
-                    "session": env.get("SESSION", ""),
-                    "claim_file": env.get("CLAIM_FILE", ""),
-                    "updated_at": env.get("UPDATED_AT", "") or file_mtime_iso(path),
-                    "state_file": str(path),
-                }
-            )
+            issue_id = env.get("ISSUE_ID", path.stem.removeprefix("issue-"))
+            claim_file = env.get("CLAIM_FILE", "")
+            in_claims = root.name == "claims"
+            if not claim_file and in_claims:
+                claim_file = str(path)
+            claimer = ""
+            if claim_file:
+                claim_base = Path(claim_file).name
+                if claim_base.startswith(f"issue-{issue_id}."):
+                    if claim_base.endswith(".env"):
+                        claim_base = claim_base.removesuffix(".env")
+                    claim_token = claim_base.split(".", 1)[1]
+                    if "." in claim_token:
+                        tail = claim_token.rsplit(".", 1)[1]
+                        if tail.isdigit():
+                            claim_token = claim_token.rsplit(".", 1)[0]
+                    claimer = claim_token
+            item = {
+                "issue_id": issue_id,
+                "session": env.get("SESSION", ""),
+                "queued_by": env.get("QUEUED_BY", ""),
+                "claim_file": claim_file,
+                "claimer": claimer,
+                "updated_at": env.get("UPDATED_AT", "") or file_mtime_iso(path),
+                "state_file": str(path),
+            }
+            items.append(item)
         return items
 
     return {

--- a/tools/tests/test-render-dashboard-snapshot.sh
+++ b/tools/tests/test-render-dashboard-snapshot.sh
@@ -20,10 +20,11 @@ mkdir -p \
   "$history_dir" \
   "$state_root/resident-workers/issues/1" \
   "$state_root/resident-workers/issues/issue-lane-recurring-general-openclaw-safe" \
-  "$state_root/retries/providers" \
-  "$state_root/retries/prs" \
-  "$state_root/scheduled-issues" \
-  "$state_root/resident-workers/issue-queue/pending"
+    "$state_root/retries/providers" \
+    "$state_root/retries/prs" \
+    "$state_root/scheduled-issues" \
+    "$state_root/resident-workers/issue-queue/pending" \
+    "$state_root/resident-workers/issue-queue/claims"
 
 cat >"$profile_dir/control-plane.yaml" <<EOF
 schema_version: "1"
@@ -112,6 +113,8 @@ RESIDENT_WORKER_SCOPE=lane
 RESIDENT_WORKER_KEY=issue-lane-recurring-general-openclaw-safe
 ISSUE_ID=1
 CODING_WORKER=openclaw
+RESIDENT_LANE_KIND=recurring
+RESIDENT_LANE_VALUE=general
 TASK_COUNT=7
 LAST_STATUS=running
 LAST_STARTED_AT=2026-03-26T15:00:00Z
@@ -144,7 +147,14 @@ EOF
 cat >"$state_root/resident-workers/issue-queue/pending/issue-2.env" <<'EOF'
 ISSUE_ID=2
 SESSION=demo-issue-2
+QUEUED_BY=heartbeat
 UPDATED_AT=2026-03-26T15:04:00Z
+EOF
+
+cat >"$state_root/resident-workers/issue-queue/claims/issue-7.issue-lane-recurring-general-openclaw-safe.999.env" <<'EOF'
+ISSUE_ID=7
+SESSION=demo-issue-7
+UPDATED_AT=2026-03-26T15:14:00Z
 EOF
 
 cat >"$history_dir/run.env" <<'EOF'
@@ -177,7 +187,7 @@ What I ran:
 Exact failure: `request to https://registry.npmjs.org/-/npm/v1/security/audits failed, reason: getaddrinfo ENOTFOUND registry.npmjs.org`
 EOF
 
-snapshot="$(ACP_PROFILE_REGISTRY_ROOT="$profile_registry_root" python3 "$SNAPSHOT_BIN" --pretty)"
+snapshot="$(ACP_PROFILE_REGISTRY_ROOT="$profile_registry_root" ACP_STATE_ROOT="$state_root" ACP_RUNS_ROOT="$runs_root" python3 "$SNAPSHOT_BIN" --pretty)"
 
 grep -q '"profile_count": 1' <<<"$snapshot"
 grep -q '"id": "demo"' <<<"$snapshot"
@@ -194,6 +204,10 @@ grep -q '"controller_live": false' <<<"$snapshot"
 grep -q '"result_kind": "implemented"' <<<"$snapshot"
 grep -q '"result_label": "Implemented"' <<<"$snapshot"
 grep -q '"recent_history_runs": 1' <<<"$snapshot"
+grep -q '"resident_lane_kind": "recurring"' <<<"$snapshot"
+grep -q '"resident_lane_value": "general"' <<<"$snapshot"
+grep -q '"queued_by": "heartbeat"' <<<"$snapshot"
+grep -q '"claimer": "issue-lane-recurring-general-openclaw-safe"' <<<"$snapshot"
 grep -q '"session": "demo-pr-9"' <<<"$snapshot"
 grep -q '"pr_number": "9"' <<<"$snapshot"
 grep -q '"last_reason": "github-api-rate-limit"' <<<"$snapshot"


### PR DESCRIPTION
## Summary

- Implements #3: Keep open: improve scheduler resilience and dashboard observability
- Host-side publication for session `agent-control-plane-issue-3`
- Commit: `1a2f022740c62f7bc17329d0e5d4b4264fb176d6`

## Verification

- Local verification was executed by the sandboxed issue worker in its isolated worktree.
- Detailed command output is available in the run artifacts for `agent-control-plane-issue-3`.
