### PR TITLE
build: enforce package provenance config

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,10 @@
     "smoke": "node ./npm/bin/agent-control-plane.js smoke",
     "test": "bash tools/tests/test-agent-control-plane-npm-cli.sh && bash tools/tests/test-agent-project-detached-launch-stable-cwd.sh && bash tools/tests/test-agent-project-claude-session-wrapper-reaps-child-on-term.sh && bash tools/tests/test-agent-project-claude-session-wrapper-does-not-retry-provider-quota.sh && bash tools/tests/test-agent-project-run-codex-resilient-uses-path-python-and-gnu-stat.sh && bash tools/tests/test-heartbeat-safe-auto-uses-path-python.sh && bash tools/tests/test-heartbeat-safe-auto-skips-self-sync.sh && bash tools/tests/test-agent-project-catch-up-terminal-prs-defaults-closed-hook.sh && bash tools/tests/test-agent-project-codex-session-wrapper-prefers-path-codex.sh && bash tools/tests/test-agent-project-codex-session-wrapper-recovers-var-tmp-logged-artifacts.sh && bash tools/tests/test-agent-project-cleanup-session-removes-registered-worktree-without-rg.sh && bash tools/tests/test-agent-project-cleanup-session-propagates-failure-with-session.sh && bash tools/tests/test-cleanup-worktree-syncs-workspace-after-cleanup-failure.sh && bash tools/tests/test-resident-issue-queue-status-contract.sh && bash tools/tests/test-agent-project-reconcile-issue-provider-quota-schedules-provider-cooldown.sh && bash tools/tests/test-agent-project-reconcile-issue-session-warns-on-cleanup-failure.sh && bash tools/tests/test-agent-project-reconcile-pr-session-warns-on-cleanup-failure.sh && bash tools/tests/test-pr-reconcile-hooks-refreshes-recurring-issue-checklist.sh && bash tools/tests/test-issue-reconcile-hooks-kick-scheduler-uses-profile.sh && bash tools/tests/test-profile-adopt-skip-anchor-sync-creates-agent-repo-root.sh && bash tools/tests/test-vendored-codex-quota-claude-oauth-only.sh && bash tools/tests/test-package-smoke-command.sh"
   },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "keywords": [
     "agents",
     "automation",

--- a/tools/tests/test-package-public-metadata.sh
+++ b/tools/tests/test-package-public-metadata.sh
@@ -21,7 +21,10 @@ if (!pkg.repository || pkg.repository.type !== "git" || pkg.repository.url !== "
   process.exit(12);
 }
 if (pkg.license !== "MIT") {
-  process.exit(2);
+    process.exit(2);
+}
+if (!pkg.publishConfig || pkg.publishConfig.access !== "public" || pkg.publishConfig.provenance !== true) {
+  process.exit(13);
 }
 for (const keyword of ["agents", "dashboard", "runtime"]) {
   if (!Array.isArray(pkg.keywords) || !pkg.keywords.includes(keyword)) {


### PR DESCRIPTION
## Summary

- Implements #1: Keep open: improve package and release trust surface
- Host-side publication for session `agent-control-plane-issue-1`
- Commit: `320674b2f8d4877a880238cda9de1bd8c06b9e65`

## Verification

- Local verification was executed by the sandboxed issue worker in its isolated worktree.
- Detailed command output is available in the run artifacts for `agent-control-plane-issue-1`.
