### PR TITLE
chore: exclude top-level SKILL.md from package tarball

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   },
   "files": [
     "README.md",
-    "SKILL.md",
     "assets/workflow-catalog.json",
     "bin/agent-control-plane",
     "bin/issue-resource-class.sh",

--- a/tools/tests/test-package-tarball-surface.sh
+++ b/tools/tests/test-package-tarball-surface.sh
@@ -32,6 +32,7 @@ function fail(message) {
 }
 
 for (const forbiddenPath of [
+  "SKILL.md",
   "tools/tests/test-agent-control-plane-npm-cli.sh",
   "tools/bin/render-dashboard-demo-media.sh",
   "tools/bin/render-architecture-infographics.sh",


### PR DESCRIPTION
## Summary

- Implements #1: Keep open: improve package and release trust surface
- Host-side publication for session `agent-control-plane-issue-1`
- Commit: `c3edd7ed75d023f0b5e3c3ab1c35b53c1571bed9`

## Verification

- Local verification was executed by the sandboxed issue worker in its isolated worktree.
- Detailed command output is available in the run artifacts for `agent-control-plane-issue-1`.
