### PR TITLE
feat(doctor): improve doctor output with actionable next steps

### DIFF
--- a/tools/bin/flow-runtime-doctor-linux.sh
+++ b/tools/bin/flow-runtime-doctor-linux.sh
@@ -119,3 +119,18 @@ fi
 
 echo ""
 echo "=== Linux Doctor Complete ==="
+echo ""
+echo "=== NEXT STEPS ==="
+if ! command -v systemctl &>/dev/null; then
+    echo "NOT on systemd: Use macOS launchd or manual tmux for runtime."
+elif ! systemctl --user is-active --quiet "${CONTROL_PLANE_NAME}.service" 2>/dev/null; then
+    echo "Service not running. Start with:"
+    echo "  systemctl --user start ${CONTROL_PLANE_NAME}.service"
+    echo "  systemctl --user enable ${CONTROL_PLANE_NAME}.service  # autostart"
+fi
+
+if ! command -v tmux &>/dev/null; then
+    echo "MISSING: tmux is required. Install:"
+    echo "  Ubuntu/Debian: sudo apt install tmux"
+    echo "  Alpine: apk add tmux"
+fi

--- a/tools/bin/flow-runtime-doctor.sh
+++ b/tools/bin/flow-runtime-doctor.sh
@@ -93,5 +93,9 @@ if [[ -n "${PROFILE_SELECTION_HINT}" ]]; then
 fi
 
 if [[ "${status}" != "ok" ]]; then
-  printf 'NEXT_STEP=bash %q %q %q\n' "${SYNC_SCRIPT}" "${SHARED_AGENT_HOME}" "${RUNTIME_HOME}"
+  printf '\n=== ACTION REQUIRED ===\n'
+  printf 'Status: %s\n' "${status}"
+  printf 'Next step: Run sync to fix issues:\n'
+  printf '  bash %q %q %q\n' "${SYNC_SCRIPT}" "${SHARED_AGENT_HOME}" "${RUNTIME_HOME}"
+  printf '\nOr run: bash %s/tools/bin/setup.sh --resume\n' "${FLOW_SKILL_DIR}"
 fi


### PR DESCRIPTION
## Summary
Improve doctor output to make next steps more obvious (Fixes #2).

## Changes

### flow-runtime-doctor.sh
- Added **ACTION REQUIRED** section when issues detected
- Shows status and clear sync command
- Suggests `setup.sh --resume` as alternative fix

### flow-runtime-doctor-linux.sh  
- Added **NEXT STEPS** section
- systemd service start/enable commands
- tmux installation hints (apt/apk)
- Clearer guidance for Linux operators

## Checklist (Fixes #2)
- [x] Improve `setup` resilience (previous work)
- [ ] Strengthen cross-platform onboarding (scripts already cross-platform)
- [x] **Improve fix-up, doctor, or dry-run output so operator next steps are more obvious**
- [ ] Keep README/operator docs aligned

## Test Plan
- [x] Run `bash tools/bin/flow-runtime-doctor.sh` - verify ACTION REQUIRED shows
- [x] Run `bash tools/bin/flow-runtime-doctor-linux.sh` - verify NEXT STEPS shows
- [x] Scripts remain syntactically valid (bash -n)