### PR TITLE
fix(sync): ensure profile-smoke.sh is synced to runtime home

### DIFF
--- a/tools/bin/sync-shared-agent-home.sh
+++ b/tools/bin/sync-shared-agent-home.sh
@@ -78,6 +78,15 @@ sync_skill_copies() {
   if [[ -n "${TARGET_FLOW_COMPAT_ALIAS}" ]]; then
     sync_tree_into_target "${FLOW_SKILL_SOURCE}" "${TARGET_FLOW_COMPAT_ALIAS}"
   fi
+
+  # Explicitly ensure profile-smoke.sh is synced to runtime home
+  local profile_smoke_source="${FLOW_SKILL_SOURCE}/tools/bin/profile-smoke.sh"
+  local profile_smoke_target="${FLOW_SKILL_TARGET}/tools/bin/profile-smoke.sh"
+  if [[ -f "${profile_smoke_source}" ]]; then
+    mkdir -p "$(dirname "${profile_smoke_target}")"
+    cp "${profile_smoke_source}" "${profile_smoke_target}"
+    chmod +x "${profile_smoke_target}"
+  fi
 }
 
 refresh_legacy_profile_templates() {


### PR DESCRIPTION
## Summary
Fix `profile-smoke.sh` not being available in runtime home after sync.

## Problem
- `profile-smoke.sh` IS in the npm package (verified: 17.6kB in npm pack)
- But ACP sync mechanism didn't copy it to runtime home reliably
- This caused `test-package-smoke-command.sh` to fail

## Solution
Added explicit copy of `profile-smoke.sh` in `sync-shared-agent-home.sh` to ensure it's always available in the runtime home's skill directory.

## Changes
- `tools/bin/sync-shared-agent-home.sh`: Added explicit copy of `profile-smoke.sh` after main sync

## Verification
- Tested sync manually: `profile-smoke.sh` now correctly copied to `${TARGET_HOME}/skills/openclaw/agent-control-plane/tools/bin/`
- Verified file is executable after sync

## Fixes
Closes #1