### PR TITLE
ci: add cross-platform matrix validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,14 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        node-version: [18, 20, 22]
+        include:
+          - os: windows-latest
+            node-version: 22
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -15,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:
-          node-version: 22
+          node-version: ${{ matrix.node-version }}
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -25,13 +32,23 @@ jobs:
       - name: Install Python deps (for adapter tests)
         run: pip install websockets aiohttp aiohttp-cors
 
-      - name: Run adapter tests (allow failures - CLIs not installed in CI)
+      - name: Install rsync (if not present)
+        if: runner.os == 'Windows'
+        run: choco install rsync -y
+
+      - name: Run package tests
+        run: npm test
+
+      - name: Run smoke tests
+        run: bash tools/bin/check-skill-contracts.sh
+
+      - name: Run adapter tests
         run: bash tools/bin/test-adapters.sh
         continue-on-error: true
 
-      - name: Run smoke tests
-        run: cd tools/bin && bash check-skill-contracts.sh
+      - name: Run dashboard snapshot tests
+        run: bash tools/tests/test-render-dashboard-snapshot.sh
         continue-on-error: true
 
       - name: Pass CI
-        run: echo "CI completed (adapter tests may show failures - expected without CLIs)"
+        run: echo "CI completed for ${{ matrix.os }} with Node ${{ matrix.node-version }}"


### PR DESCRIPTION
## Summary
Add cross-platform CI matrix to validate ACP on multiple platforms and Node.js versions.

## Changes
- Add matrix with `ubuntu-latest`, `macos-latest`, and `windows-latest`
- Test with Node.js 18, 20, and 22
- Install `rsync` on Windows via Chocolatey
- Run package tests, smoke tests, adapter tests, and dashboard tests

## Progress on Issue #2
- [x] Improve `setup` resilience (DONE)
- [x] Improve fix-up, doctor, or dry-run output (DONE - PR #40)
- [~] Strengthen cross-platform onboarding behavior (IN PROGRESS - this PR)
- [ ] Keep README/operator docs aligned (pending)

## Testing
- CI will validate the changes across multiple platforms
- Local test: `npm test` passes

Related to #2