### PR TITLE
feat(worker-status): add next-step suggestions for failure reasons

### DIFF
--- a/tools/bin/agent-project-worker-status
+++ b/tools/bin/agent-project-worker-status
@@ -74,6 +74,33 @@ failure_reason_from_output() {
   return 1
 }
 
+next_step_message() {
+  local reason="${1:-}"
+  case "$reason" in
+    usage-limit)
+      echo "Wait for quota reset (usually 24h), or switch to another provider/account in the profile"
+      ;;
+    no-codex-output-before-stall-threshold|no-codex-progress-before-stall-threshold)
+      echo "Check worker log for stall patterns, restart the session, or switch to a different backend"
+      ;;
+    no-agent-output-before-stall-threshold|no-agent-progress-before-stall-threshold)
+      echo "Check worker log for stall patterns, restart the session, or switch to a different backend"
+      ;;
+    claude-exit-failed|openclaw-exit-failed)
+      echo "Investigate worker logs, check if the binary crashed, or try re-running the session"
+      ;;
+    worker-exit-failed)
+      echo "Check the worker process logs and verify the backend is installed and configured correctly"
+      ;;
+    runner-aborted-before-completion)
+      echo "The worker process was killed before completion. Check system resources and re-run the session"
+      ;;
+    *)
+      echo "Check the session logs and re-run the session if needed"
+      ;;
+  esac
+}
+
 if tmux has-session -t "$session" 2>/dev/null; then
   status="RUNNING"
 fi
@@ -182,6 +209,7 @@ if [[ -n "$exit_code" ]]; then
 fi
 if [[ -n "$failure_reason" ]]; then
   printf 'FAILURE_REASON=%s\n' "$failure_reason"
+  printf 'NEXT_STEP=%s\n' "$(next_step_message "$failure_reason")"
 fi
 if [[ -n "$thread_id" ]]; then
   printf 'THREAD_ID=%s\n' "$thread_id"


### PR DESCRIPTION
## Summary
Add actionable next-step suggestions when worker sessions fail.

## Changes
- Add `next_step_message()` function to `agent-project-worker-status`
- Output `NEXT_STEP=` message when failure reason is present
- Provides specific suggestions for each failure type

## Supported Failure Reasons
- `usage-limit`: Wait for quota reset or switch provider
- `no-*-output/stale-threshold`: Check logs, restart, or switch backend
- `*-exit-failed`: Investigate logs, check binary installation
- `runner-aborted-before-completion`: Check system resources

## Progress on Issue #3
- [x] Dashboard visibility improvements (DONE - PR #41, #42)
- [x] Add smoke/doctor/regression coverage (DONE - PR #42)
- [~] Tighten runtime/reconcile behavior (IN PROGRESS - this PR)
- [ ] Harden recurring/scheduled issue execution (pending)

## Testing
- Syntax check: `bash -n` passes
- Function returns correct suggestions for each failure type

Related to #3