### PR TITLE
fix(package): add render-flow-config.sh to files field

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "tools/bin/heartbeat-*.sh",
     "tools/bin/github-*.sh",
     "tools/bin/profile-*.sh",
+    "tools/bin/render-flow-config.sh",
     "tools/bin/test-smoke.sh",
     "tools/bin/*-adapter.sh",
     "tools/bin/adapter-*.sh",


### PR DESCRIPTION
## Summary
Add `tools/bin/render-flow-config.sh` to package.json `files` field.

## Problem
- `render-flow-config.sh` was not included in the npm package
- This caused `profile-smoke.sh` to fail when run from the installed package
- The `test-package-smoke-command.sh` test was failing

## Solution
Added `"tools/bin/render-flow-config.sh"` to the `files` field in package.json.

## Verification
- `npm pack --dry-run` now shows `render-flow-config.sh` (5.9kB)
- `test-package-smoke-command.sh` now PASSES
- All smoke test steps pass

## Progress on Issue #1
- [x] Reduce shipped public package surface (DONE)
- [x] Tighten package-level regression coverage (NOW COMPLETE - test passes)
- [x] Improve release automation/provenance (DONE)
- [x] Refresh public docs/release checklists (DONE)

**Issue #1 is now 100% complete!**

Fixes #1