### PR TITLE
feat(scheduler): validate repo accessibility before kicking

### DIFF
--- a/tools/bin/kick-scheduler.sh
+++ b/tools/bin/kick-scheduler.sh
@@ -20,6 +20,25 @@ FLOW_SAFE_AUTO_SCRIPT="${ACP_FLOW_HEARTBEAT_SCRIPT:-${F_LOSNING_FLOW_HEARTBEAT_S
 STATE_DIR="${ACP_SCHEDULER_KICK_STATE_DIR:-${STATE_ROOT}/kick-scheduler}"
 PID_FILE="${STATE_DIR}/pid"
 
+# Validate repo configuration before proceeding
+if [[ -z "${REPO_SLUG:-}" ]]; then
+  echo "KICK_STATUS=repo-not-configured"
+  exit 1
+fi
+
+# Basic format check for repo slug
+if [[ "${REPO_SLUG}" =~ ^https?:// ]]; then
+  # Looks like a URL - validate it's reachable
+  if ! curl -s --connect-timeout 5 "${REPO_SLUG}" >/dev/null 2>&1; then
+    echo "KICK_STATUS=repo-not-reachable"
+    exit 1
+  fi
+elif [[ ! "${REPO_SLUG}" =~ ^[^/]+/[^/]+$ ]]; then
+  # Not a valid owner/repo format
+  echo "KICK_STATUS=repo-invalid-format"
+  exit 1
+fi
+
 mkdir -p "${STATE_DIR}"
 
 active_heartbeat_pid() {


### PR DESCRIPTION
## Summary
Add repo accessibility validation before kicking the scheduler.

## Changes
- Added pre-check for REPO_SLUG configuration
- For URLs (http/https): validate reachability via curl
- For owner/repo format: validate format
- Exit with clear status if validation fails

## Progress on Issue #3
- [x] Dashboard visibility improvements (DONE - PR #41, #42)
- [x] Add smoke/doctor/regression coverage (DONE - PR #42)
- [x] Tighten runtime/reconcile behavior (DONE - PR #45)
- [~] Harden recurring/scheduled issue execution (IN PROGRESS - this PR)

## Testing
- Syntax check: `bash -n` passes
- Validates repo slug format
- Validates URL reachability for self-hosted forges

Related to #3