### PR TITLE
fix(scheduler): harden recurring issue execution (Fixes #3)

### DIFF
--- a/tools/bin/kick-scheduler-wrapper.sh
+++ b/tools/bin/kick-scheduler-wrapper.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Wrapper for kick-scheduler to add timeout and logging
+set -euo pipefail
+
+PID_FILE="${1:?PID file required}"
+DELAY_SECONDS="${2:?Delay seconds required}"
+BOOTSTRAP_SCRIPT="${3:?Bootstrap script required}"
+FLOW_SAFE_AUTO_SCRIPT="${4:?Flow safe auto script required}"
+REPO_SLUG="${5:?Repo slug required}"
+STATE_DIR="${6:?State dir required}"
+KICK_TIMEOUT_SECONDS="${ACP_KICK_TIMEOUT_SECONDS:-3600}"
+KICK_LOG="${STATE_DIR}/kick-scheduler.log"
+
+trap 'rm -f "$PID_FILE"' EXIT
+
+log() {
+  echo "$(date -u +"%Y-%m-%dT%H:%M:%SZ") [wrapper] $*" >>"${KICK_LOG}"
+}
+
+log "Delay ${DELAY_SECONDS}s, timeout ${KICK_TIMEOUT_SECONDS}s"
+
+sleep "${DELAY_SECONDS}"
+
+# Check for active heartbeat
+active_pid="$(ps -ax -o pid=,command= | while read -r pid command; do
+  [[ -n "${pid:-}" ]] || continue
+  case "$command" in
+    *"${BOOTSTRAP_SCRIPT}"*|*"${FLOW_SAFE_AUTO_SCRIPT}"*|*"agent-project-heartbeat-loop --repo-slug ${REPO_SLUG}"*)
+      printf "%s\n" "$pid"
+      break
+      ;;
+  esac
+done)"
+
+if [[ -n "$active_pid" ]]; then
+  log "Active heartbeat found (PID ${active_pid}), skipping"
+  exit 0
+fi
+
+log "Starting bootstrap with timeout ${KICK_TIMEOUT_SECONDS}s"
+timeout "${KICK_TIMEOUT_SECONDS}" "${BOOTSTRAP_SCRIPT}" >>"${KICK_LOG}" 2>&1 || true
+log "Bootstrap completed with exit code $?"

--- a/tools/bin/kick-scheduler.sh
+++ b/tools/bin/kick-scheduler.sh
@@ -69,24 +69,27 @@ if [[ -f "${PID_FILE}" ]]; then
   fi
 fi
 
-export DELAY_SECONDS BOOTSTRAP_SCRIPT FLOW_SAFE_AUTO_SCRIPT PID_FILE REPO_SLUG
-nohup bash -lc '
-  trap '\''rm -f "$PID_FILE"'\'' EXIT
-  sleep "$DELAY_SECONDS"
-  active_pid="$(ps -ax -o pid=,command= | while read -r pid command; do
-    [[ -n "${pid:-}" ]] || continue
-    case "$command" in
-      *"$BOOTSTRAP_SCRIPT"*|*"$FLOW_SAFE_AUTO_SCRIPT"*|*"agent-project-heartbeat-loop --repo-slug $REPO_SLUG"*)
-        printf "%s\n" "$pid"
-        break
-        ;;
-    esac
-  done)"
-  if [[ -n "$active_pid" ]]; then
-    exit 0
+export DELAY_SECONDS BOOTSTRAP_SCRIPT FLOW_SAFE_AUTO_SCRIPT PID_FILE REPO_SLUG STATE_DIR
+KICK_LOG="${STATE_DIR}/kick-scheduler.log"
+KICK_TIMEOUT_SECONDS="${ACP_KICK_TIMEOUT_SECONDS:-3600}"
+
+# Cleanup stale PID file if process not running
+if [[ -f "${PID_FILE}" ]]; then
+  stale_pid="$(cat "${PID_FILE}" 2>/dev/null || true)"
+  if [[ -n "${stale_pid}" ]] && ! kill -0 "${stale_pid}" 2>/dev/null; then
+    echo "$(date -u +"%Y-%m-%dT%H:%M:%SZ") [cleanup] Removing stale PID file (PID ${stale_pid})" >>"${KICK_LOG}"
+    rm -f "${PID_FILE}"
   fi
-  "$BOOTSTRAP_SCRIPT" >/dev/null 2>&1 || true
-' >/dev/null 2>&1 &
+fi
+
+nohup "${SCRIPT_DIR}/kick-scheduler-wrapper.sh" \
+  "${PID_FILE}" \
+  "${DELAY_SECONDS}" \
+  "${BOOTSTRAP_SCRIPT}" \
+  "${FLOW_SAFE_AUTO_SCRIPT}" \
+  "${REPO_SLUG}" \
+  "${STATE_DIR}" \
+  >/dev/null 2>&1 &
 
 bg_pid="$!"
 printf '%s\n' "${bg_pid}" >"${PID_FILE}"


### PR DESCRIPTION
## Summary
- Add wrapper script with timeout (default 1 hour) for bootstrap script
- Add logging to kick-scheduler for better debugging
- Cleanup stale PID files before launching new scheduler
- Prevent hung bootstrap processes using timeout command

## Changes
- `tools/bin/kick-scheduler-wrapper.sh`: new wrapper script with timeout and logging
- `tools/bin/kick-scheduler.sh`: use wrapper, add stale PID cleanup

## Verification
- `bash -n tools/bin/kick-scheduler.sh`: syntax OK
- `bash -n tools/bin/kick-scheduler-wrapper.sh`: syntax OK

Fixes #3