### PR TITLE
fix(onboarding): cross-platform timeout detection (See #2)

### DIFF
--- a/tools/bin/kick-scheduler-wrapper.sh
+++ b/tools/bin/kick-scheduler-wrapper.sh
@@ -17,7 +17,18 @@ log() {
   echo "$(date -u +"%Y-%m-%dT%H:%M:%SZ") [wrapper] $*" >>"${KICK_LOG}"
 }
 
-log "Delay ${DELAY_SECONDS}s, timeout ${KICK_TIMEOUT_SECONDS}s"
+# Cross-platform timeout command detection
+TIMEOUT_CMD=""
+if command -v timeout &>/dev/null; then
+  TIMEOUT_CMD="timeout"
+elif command -v gtimeout &>/dev/null; then
+  # macOS with coreutils installed via brew
+  TIMEOUT_CMD="gtimeout"
+else
+  log "WARNING: 'timeout' command not found, bootstrap will run without timeout"
+fi
+
+log "Delay ${DELAY_SECONDS}s, timeout ${KICK_TIMEOUT_SECONDS}s (timeout cmd: ${TIMEOUT_CMD:-none})"
 
 sleep "${DELAY_SECONDS}"
 
@@ -37,6 +48,11 @@ if [[ -n "$active_pid" ]]; then
   exit 0
 fi
 
-log "Starting bootstrap with timeout ${KICK_TIMEOUT_SECONDS}s"
-timeout "${KICK_TIMEOUT_SECONDS}" "${BOOTSTRAP_SCRIPT}" >>"${KICK_LOG}" 2>&1 || true
+if [[ -n "${TIMEOUT_CMD}" ]]; then
+  log "Starting bootstrap with timeout ${KICK_TIMEOUT_SECONDS}s using ${TIMEOUT_CMD}"
+  "${TIMEOUT_CMD}" "${KICK_TIMEOUT_SECONDS}" "${BOOTSTRAP_SCRIPT}" >>"${KICK_LOG}" 2>&1 || true
+else
+  log "Starting bootstrap without timeout (timeout command not available)"
+  "${BOOTSTRAP_SCRIPT}" >>"${KICK_LOG}" 2>&1 || true
+fi
 log "Bootstrap completed with exit code $?"


### PR DESCRIPTION
## Summary
- Detect `timeout` or `gtimeout` command for cross-platform compatibility
- Fall back gracefully when timeout is not available
- Log warning for operators

## Changes
- `tools/bin/kick-scheduler-wrapper.sh`: improved cross-platform support

## Verification
- `bash -n tools/bin/kick-scheduler-wrapper.sh`: syntax OK

See #2