### PR TITLE
test(package): unpacked size budget check (Issue #1, round 5)

### DIFF
--- a/tools/tests/test-package-tarball-surface.sh
+++ b/tools/tests/test-package-tarball-surface.sh
@@ -100,6 +100,7 @@ const result = {
   size: pack.size,
   unpackedSize: pack.unpackedSize,
   entryCount: pack.entryCount,
+  averageFileSize: Math.round(pack.size / pack.entryCount),
 };
 
 console.log(JSON.stringify(result));
@@ -107,6 +108,11 @@ console.log(JSON.stringify(result));
 // Compressed-size budget guard: fail if the tarball creeps above 400 KB.
 if (pack.size > 400 * 1024) {
   fail(`tarball compressed size ${Math.round(pack.size / 1024)} KB exceeds 400 KB budget`);
+}
+
+// Unpacked-size budget guard: fail if unpacked size exceeds 1.5 MB.
+if (pack.unpackedSize > 1.5 * 1024 * 1024) {
+  fail(`tarball unpacked size ${Math.round(pack.unpackedSize / 1024 / 1024 * 10) / 10} MB exceeds 1.5 MB budget`);
 }
 NODE
 


### PR DESCRIPTION
## Summary
- Add unpacked size budget guard (1.5 MB limit)
- Add average file size to test output
- Tighten package-level regression coverage

## Changes
- `tools/tests/test-package-tarball-surface.sh`: added unpacked size check

## Verification
- `bash -n tools/tests/test-package-tarball-surface.sh`: syntax OK

Related to #1 round 5