### PR TITLE
feat: add prepublishOnly validation (Issue #1, round 7)

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
   "scripts": {
     "doctor": "node ./npm/bin/agent-control-plane.js doctor",
     "smoke": "node ./npm/bin/agent-control-plane.js smoke",
-    "test": "bash tools/tests/test-package-surface.sh && bash tools/tests/test-package-public-metadata.sh"
+    "test": "bash tools/tests/test-package-surface.sh && bash tools/tests/test-package-public-metadata.sh",
+    "prepublishOnly": "npm run test && bash tools/tests/test-package-surface.sh && echo '✓ Package validation passed'"
   },
   "files": [
     "README.md",


### PR DESCRIPTION
## Summary
Add `prepublishOnly` script to validate package before publishing to npm.

## Changes
- Add `prepublishOnly` script to package.json
- Runs tests and package surface validation before publish
- Prevents publishing broken or incomplete packages
- Ensures all checks pass before `npm publish`

## Benefits
- Catches issues before publishing
- Validates package contents automatically
- Reduces risk of broken releases

## Related Issue
Fixes #1 (Round 7 of ongoing work)

## Checklist
- [x] prepublishOnly script added
- [x] Runs tests before publish
- [x] Validates package surface
- [x] Prevents broken publishes