### PR TITLE
feat: add Dependabot config (Issue #1, round 9)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,49 @@
+version: 2
+updates:
+  # npm dependencies
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+    open-pull-requests-limit: 10
+    reviewers:
+      - "ducminhnguyen0319"
+    labels:
+      - "dependencies"
+      - "automerge"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      # Group minor and patch updates together
+      production-dependencies:
+        dependency-type: "production"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
+      development-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
+    ignore:
+      # Ignore major version updates (require manual review)
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+    
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "chore"
+      include: "scope"


### PR DESCRIPTION
## Summary
Add Dependabot configuration for automated dependency updates.

## Changes
- Create `.github/dependabot.yml` with weekly checks (Monday 9AM)
- Monitor npm dependencies (production + dev)
- Monitor GitHub Actions updates
- Group minor/patch updates, ignore major (manual review)
- Auto-assign reviewer, add labels (dependencies, automerge, ci)
- Limit to 10 npm PRs and 5 actions PRs per week

## Benefits
- Automated dependency updates reduce manual maintenance
- Security patches applied faster
- Grouped updates reduce PR spam
- Major updates require manual review (safety)

## Related Issue
Fixes #1 (Round 9 of ongoing work)

## Checklist
- [x] .github/dependabot.yml created
- [x] npm dependencies monitoring configured
- [x] GitHub Actions monitoring configured
- [x] Update groups and limits set
- [x] Labels and reviewer auto-assigned