### PR TITLE
feat: shell completion scripts (Issue #2, round 11)

### DIFF
--- a/tools/completion/_acp
+++ b/tools/completion/_acp
@@ -1,0 +1,91 @@
+# zsh completion for agent-control-plane
+# Save to /path/to/agent-control-plane/tools/completion/_acp
+
+#compdef agent-control-plane
+
+local -a commands
+commands=(
+  'doctor:Check ACP installation health'
+  'smoke:Run smoke tests'
+  'init:Initialize a new profile'
+  'runtime:Manage runtime (start/stop/status)'
+  'dashboard:Manage dashboard (start/stop/status)'
+  'sync:Sync runtime to latest'
+  'help:Show help'
+)
+
+local -a workers
+workers=(codex claude openclaw ollama pi opencode kilo gemini-cli nanoclaw picoclaw)
+
+local -a providers
+providers=(github gitea)
+
+local -a runtime_cmds
+runtime_cmds=(start stop status restart)
+
+local -a dashboard_cmds
+dashboard_cmds=(start stop status)
+
+local curcontext="$curcontext" state line
+typeset -A opt_args
+
+_arguments -C \
+  '1: :->command' \
+  '*::arg:->args' \
+
+case $state in
+  command)
+    _describe 'command' commands
+    ;;
+  args)
+    case $line[1] in
+      doctor)
+        _arguments \
+          '--profile-id[Profile ID]:profile ID:->profiles' \
+          '--json[Output JSON]'
+        ;;
+      smoke)
+        _arguments \
+          '--profile-id[Profile ID]:profile ID:->profiles' \
+          '--json[Output JSON]'
+        ;;
+      init)
+        _arguments \
+          '--profile-id[Profile ID]:profile ID' \
+          '--repo-slug[Repository slug (owner/repo)]:repo slug' \
+          '--forge-provider[Forge provider]:forge provider:($providers)' \
+          '--repo-root[Repository root path]:repo root:_files -/' \
+          '--agent-root[Agent root path]:agent root:_files -/' \
+          '--worktree-root[Worktree root path]:worktree root:_files -/' \
+          '--coding-worker[Coding worker]:worker:($workers)' \
+          '--gitea-base-url[Gitea base URL]:URL' \
+          '--gitea-token[Gitea token]:token'
+        ;;
+      runtime)
+        _arguments \
+          '1:runtime command:($runtime_cmds)' \
+          '--profile-id[Profile ID]:profile ID:->profiles'
+        ;;
+      dashboard)
+        _arguments \
+          '1:dashboard command:($dashboard_cmds)' \
+          '--profile-id[Profile ID]:profile ID:->profiles'
+        ;;
+      sync)
+        _arguments \
+          '--profile-id[Profile ID]:profile ID:->profiles'
+        ;;
+    esac
+    ;;
+esac
+
+case $state in
+  profiles)
+    local profiles_dir="$HOME/.agent-runtime/control-plane/profiles"
+    if [[ -d $profiles_dir ]]; then
+      local -a profiles
+      profiles=($profiles_dir/*(N:t))
+      _describe 'profile' profiles
+    fi
+    ;;
+esac

--- a/tools/completion/acp.bash
+++ b/tools/completion/acp.bash
@@ -1,0 +1,93 @@
+# bash completion for agent-control-plane
+# Source this file from your .bashrc or .bash_profile:
+#   source /path/to/agent-control-plane/tools/completion/acp.bash
+
+_acp_completion() {
+  local cur prev words cword
+  _init_completion || return
+
+  # Commands
+  local commands="doctor smoke init runtime dashboard sync help"
+
+  # Options for each command
+  local doctor_opts="--profile-id --json"
+  local smoke_opts="--profile-id --json"
+  local init_opts="--profile-id --repo-slug --forge-provider --repo-root --agent-root --worktree-root --coding-worker --gitea-base-url --gitea-token"
+  local runtime_opts="start stop status restart --profile-id"
+  local dashboard_opts="start stop status --profile-id"
+  local sync_opts="--profile-id"
+
+  # Worker types
+  local workers="codex claude openclaw ollama pi opencode kilo gemini-cli nanoclaw picoclaw"
+
+  # Forge providers
+  local providers="github gitea"
+
+  # If no command yet, complete with commands
+  if [[ $cword -eq 1 ]]; then
+    COMPREPLY=($(compgen -W "$commands" -- "$cur"))
+    return
+  fi
+
+  local cmd=${words[1]}
+
+  case "$cmd" in
+    doctor)
+      COMPREPLY=($(compgen -W "$doctor_opts" -- "$cur"))
+      ;;
+    smoke)
+      COMPREPLY=($(compgen -W "$smoke_opts" -- "$cur"))
+      ;;
+    init)
+      case "$prev" in
+        --forge-provider)
+          COMPREPLY=($(compgen -W "$providers" -- "$cur"))
+          return
+          ;;
+        --coding-worker)
+          COMPREPLY=($(compgen -W "$workers" -- "$cur"))
+          return
+          ;;
+        *)
+          COMPREPLY=($(compgen -W "$init_opts" -- "$cur"))
+          ;;
+      esac
+      ;;
+    runtime)
+      local runtime_cmds="start stop status restart"
+      if [[ $cword -eq 2 ]]; then
+        COMPREPLY=($(compgen -W "$runtime_cmds" -- "$cur"))
+      else
+        COMPREPLY=($(compgen -W "$runtime_opts" -- "$cur"))
+      fi
+      ;;
+    dashboard)
+      local dashboard_cmds="start stop status"
+      if [[ $cword -eq 2 ]]; then
+        COMPREPLY=($(compgen -W "$dashboard_cmds" -- "$cur"))
+      else
+        COMPREPLY=($(compgen -W "$dashboard_opts" -- "$cur"))
+      fi
+      ;;
+    sync)
+      COMPREPLY=($(compgen -W "$sync_opts" -- "$cur"))
+      ;;
+    *)
+      COMPREPLY=($(compgen -W "$commands" -- "$cur"))
+      ;;
+  esac
+
+  # Complete profile IDs from ~/.agent-runtime/control-plane/profiles/
+  if [[ "$cur" == --profile-id* || "$prev" == "--profile-id" ]]; then
+    local profiles_dir="$HOME/.agent-runtime/control-plane/profiles"
+    if [[ -d "$profiles_dir" ]]; then
+      local profiles=$(ls -1 "$profiles_dir" 2>/dev/null)
+      COMPREPLY=($(compgen -W "$profiles" -- "$cur"))
+    fi
+  fi
+}
+
+complete -F _acp_completion agent-control-plane
+complete -F _acp_completion npx  # Also complete for npx agent-control-plane@latest
+
+# vim:ft=bash


### PR DESCRIPTION
## Summary
Add shell completion scripts for bash and zsh to improve CLI usability.

## Changes
- Create `tools/completion/acp.bash` for bash completion
- Create `tools/completion/_acp` for zsh completion
- Complete commands: doctor, smoke, init, runtime, dashboard, sync
- Complete options: --profile-id, --forge-provider, --coding-worker, etc.
- Complete profile IDs from ~/.agent-runtime/control-plane/profiles/
- Complete worker types and forge providers

## Usage
```bash
# Bash
source tools/completion/acp.bash

# Zsh
fpath=(/path/to/tools/completion $fpath)
compinit
```

## Related Issue
Fixes #2 (Round 11 of ongoing work)

## Checklist
- [x] acp.bash created
- [x] _acp created for zsh
- [x] Commands completion
- [x] Options completion
- [x] Profile IDs completion
- [x] Workers and providers completion