### PR TITLE
feat: dashboard export to JSON (Issue #3, round 12)

### DIFF
--- a/tools/dashboard/app-v2.js
+++ b/tools/dashboard/app-v2.js
@@ -892,6 +892,21 @@ connectWebSocket();
 // Scheduler Status
 let schedulerStatus = null;
 
+function exportSnapshot() {
+  if (!window._acpSnapshot) {
+    alert('No snapshot data available yet.');
+    return;
+  }
+  const dataStr = JSON.stringify(window._acpSnapshot, null, 2);
+  const dataBlob = new Blob([dataStr], { type: 'application/json' });
+  const url = URL.createObjectURL(dataBlob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = `acp-snapshot-${new Date().toISOString().slice(0, 10)}.json`;
+  link.click();
+  URL.revokeObjectURL(url);
+}
+
 async function fetchSchedulerStatus() {
   try {
     const response = await fetch("/api/scheduler-status", { cache: "no-store" });


### PR DESCRIPTION
## Summary
Add dashboard data export functionality for offline analysis.

## Changes
- Add `exportSnapshot()` function to app-v2.js
- Converts `window._acpSnapshot` to JSON
- Downloads as `acp-snapshot-YYYY-MM-DD.json`
- Checks for snapshot data before exporting

## Usage
Call `exportSnapshot()` from browser console, or add a button to the UI.

## Related Issue
Fixes #3 (Round 12 of ongoing work)

## Checklist
- [x] exportSnapshot() function added
- [x] JSON download implemented
- [x] Snapshot data validation