### PR TITLE
fix: reconcile author detection + portable adapter timeout

### DIFF
--- a/tools/bin/adapter-interface.sh
+++ b/tools/bin/adapter-interface.sh
@@ -81,6 +81,64 @@ adapter_load() {
   source "$impl"
 }
 
+# Run a command with a wall-clock timeout. Uses GNU `timeout` / `gtimeout`
+# when available, else falls back to a python3 wrapper, else perl. Streams
+# the child's stdout/stderr to the caller. Exits 124 on timeout.
+# Usage: adapter_run_with_timeout SECS CMD [ARGS...]
+adapter_run_with_timeout() {
+  local secs="${1:?usage: adapter_run_with_timeout SECS CMD [ARGS...]}"
+  shift
+  if command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "${secs}" "$@"
+    return $?
+  fi
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "${secs}" "$@"
+    return $?
+  fi
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - "${secs}" "$@" <<'PY'
+import subprocess, sys
+secs = float(sys.argv[1])
+cmd = sys.argv[2:]
+try:
+    proc = subprocess.Popen(cmd)
+except FileNotFoundError as exc:
+    sys.stderr.write("adapter_run_with_timeout: %s\n" % exc)
+    sys.exit(127)
+try:
+    proc.wait(timeout=secs)
+except subprocess.TimeoutExpired:
+    proc.terminate()
+    try:
+        proc.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+    sys.exit(124)
+sys.exit(proc.returncode)
+PY
+    return $?
+  fi
+  if command -v perl >/dev/null 2>&1; then
+    perl -e '
+my $secs = shift @ARGV;
+my $pid = fork();
+die "fork: $!" unless defined $pid;
+if ($pid == 0) { exec { $ARGV[0] } @ARGV or exit 127; }
+local $SIG{ALRM} = sub { kill "TERM", $pid; sleep 10; kill "KILL", $pid; waitpid($pid, 0); exit 124; };
+alarm $secs;
+waitpid($pid, 0);
+alarm 0;
+my $rc = $? >> 8;
+exit $rc;
+' "${secs}" "$@"
+    return $?
+  fi
+  echo "adapter_run_with_timeout: no gtimeout/timeout/python3/perl available; running without timeout" >&2
+  "$@"
+}
+
 # Validate adapter implements required functions
 adapter_validate() {
   local missing=()

--- a/tools/bin/claude-adapter.sh
+++ b/tools/bin/claude-adapter.sh
@@ -49,12 +49,22 @@ adapter_run() {
   local timeout_seconds="${CLAUDE_TIMEOUT_SECONDS:-900}"
   
   echo "Claude adapter: Running session ${session}"
-  
+
   cd "${worktree}" || return 1
-  
+
+  local sandbox_subdir="${ACP_SANDBOX_SUBDIR:-.openclaw-artifacts}"
+  local sandbox_run_dir="${worktree%/}/${sandbox_subdir}/${session}"
+  mkdir -p "${sandbox_run_dir}" 2>/dev/null || true
+  export ACP_SESSION="${session}"
+  export ACP_RUN_DIR="${sandbox_run_dir}"
+  export ACP_RESULT_FILE="${sandbox_run_dir}/result.env"
+  export F_LOSNING_SESSION="${session}"
+  export F_LOSNING_RUN_DIR="${sandbox_run_dir}"
+  export F_LOSNING_RESULT_FILE="${sandbox_run_dir}/result.env"
+
   prompt="$(cat "${prompt_file}")"
-  
-  if ! timeout "${timeout_seconds}" claude \
+
+  if ! adapter_run_with_timeout "${timeout_seconds}" claude \
     --permission-mode "${permission_mode}" \
     --model "${ADAPTER_MODEL}" \
     --print \

--- a/tools/bin/codex-adapter.sh
+++ b/tools/bin/codex-adapter.sh
@@ -73,7 +73,7 @@ adapter_run() {
   cd "${worktree}" || return 1
   
   # Run claude with the prompt
-  if ! timeout "${timeout_seconds}" claude \
+  if ! adapter_run_with_timeout "${timeout_seconds}" claude \
     --permission-mode "${permission_mode}" \
     --model "${ADAPTER_MODEL}" \
     --print \

--- a/tools/bin/flow-forge-lib.sh
+++ b/tools/bin/flow-forge-lib.sh
@@ -1151,8 +1151,10 @@ flow_github_pr_view_json() {
   fi
 
   if flow_github_graphql_available "${repo_slug}" \
-    && pr_json="$(gh pr view "${pr_number}" -R "${repo_slug}" --json number,title,body,url,headRefName,baseRefName,mergeStateStatus,statusCheckRollup,labels,comments,state,isDraft 2>/dev/null)"; then
-    printf '%s\n' "${pr_json}"
+    && pr_json="$(gh pr view "${pr_number}" -R "${repo_slug}" --json number,title,body,url,headRefName,baseRefName,mergeStateStatus,statusCheckRollup,labels,comments,state,isDraft,author 2>/dev/null)"; then
+    printf '%s\n' "${pr_json}" \
+      | jq '. + {authorLogin: ((.author.login) // "")}' 2>/dev/null \
+      || printf '%s\n' "${pr_json}"
     return 0
   fi
 

--- a/tools/bin/flow-runtime-doctor.sh
+++ b/tools/bin/flow-runtime-doctor.sh
@@ -88,12 +88,13 @@ printf 'WORKFLOW_CATALOG=%s\n' "${CATALOG_FILE}"
 printf 'WORKFLOW_CATALOG_EXISTS=%s\n' "${catalog_exists}"
 # Check timeout command (needed for scheduler cross-platform)
 if command -v timeout &>/dev/null; then
-  printf 'TIMEOUT_CMD=%s\n' "timeout"
+  TIMEOUT_CMD="timeout"
 elif command -v gtimeout &>/dev/null; then
-  printf 'TIMEOUT_CMD=%s\n' "gtimeout (from coreutils)"
+  TIMEOUT_CMD="gtimeout (from coreutils)"
 else
-  printf 'TIMEOUT_CMD=%s\n' "missing (install coreutils for timeout command)"
+  TIMEOUT_CMD="missing (install coreutils for timeout command)"
 fi
+printf 'TIMEOUT_CMD=%s\n' "${TIMEOUT_CMD}"
 printf 'DOCTOR_STATUS=%s\n' "${status}"
 
 # Provide clear next steps based on state
@@ -116,7 +117,7 @@ else
 fi
 
 # Cross-platform tips
-if [[ "${TIMEOUT_CMD}" == *"missing"* ]]; then
+if [[ "${TIMEOUT_CMD:-}" == *"missing"* ]]; then
   printf '\n⚠ Cross-Platform Tip: Install coreutils for timeout command:\n'
   if [[ "$(uname -s)" == "Darwin" ]]; then
     printf '  macOS: brew install coreutils\n'

--- a/tools/bin/kilo-adapter.sh
+++ b/tools/bin/kilo-adapter.sh
@@ -85,7 +85,7 @@ adapter_run() {
   
   # Run kilo and capture output
   local output
-  if ! output="$(timeout "${timeout_seconds}" kilo --model "${ADAPTER_MODEL}" "${prompt}" 2>&1)"; then
+  if ! output="$(adapter_run_with_timeout "${timeout_seconds}" kilo --model "${ADAPTER_MODEL}" "${prompt}" 2>&1)"; then
     echo "ERROR: Kilo run failed or timed out after ${timeout_seconds}s"
     return 1
   fi

--- a/tools/bin/ollama-adapter.sh
+++ b/tools/bin/ollama-adapter.sh
@@ -99,24 +99,9 @@ adapter_run() {
   local prompt
   prompt="$(cat "${prompt_file}")"
   
-  # Run ollama with the prompt
-  # Use perl for timeout on macOS (which lacks GNU timeout)
-  if command -v timeout >/dev/null 2>&1; then
-    if ! timeout "${timeout_seconds}" ollama run "${ADAPTER_MODEL}" "${prompt}" 2>&1; then
-      echo "ERROR: Ollama run failed or timed out after ${timeout_seconds}s"
-      return 1
-    fi
-  elif command -v perl >/dev/null 2>&1; then
-    if ! perl -e "alarm ${timeout_seconds}; exec @ARGV" ollama run "${ADAPTER_MODEL}" "${prompt}" 2>&1; then
-      echo "ERROR: Ollama run failed or timed out after ${timeout_seconds}s"
-      return 1
-    fi
-  else
-    # No timeout available, run without timeout
-    if ! ollama run "${ADAPTER_MODEL}" "${prompt}" 2>&1; then
-      echo "ERROR: Ollama run failed"
-      return 1
-    fi
+  if ! adapter_run_with_timeout "${timeout_seconds}" ollama run "${ADAPTER_MODEL}" "${prompt}" 2>&1; then
+    echo "ERROR: Ollama run failed or timed out after ${timeout_seconds}s"
+    return 1
   fi
   
   echo "Ollama adapter: Session ${session} completed"

--- a/tools/bin/openclaw-adapter.sh
+++ b/tools/bin/openclaw-adapter.sh
@@ -54,7 +54,7 @@ adapter_run() {
   
   prompt="$(cat "${prompt_file}")"
   
-  if ! timeout "${timeout_seconds}" openclaw --model "${ADAPTER_MODEL}" "${prompt}" 2>&1; then
+  if ! adapter_run_with_timeout "${timeout_seconds}" openclaw --model "${ADAPTER_MODEL}" "${prompt}" 2>&1; then
     echo "ERROR: OpenClaw run failed"
     return 1
   fi

--- a/tools/bin/opencode-adapter.sh
+++ b/tools/bin/opencode-adapter.sh
@@ -83,7 +83,7 @@ adapter_run() {
   
   prompt="$(cat "${prompt_file}")"
   
-  if ! timeout "${timeout_seconds}" crush --model "${ADAPTER_MODEL}" "${prompt}" 2>&1; then
+  if ! adapter_run_with_timeout "${timeout_seconds}" crush --model "${ADAPTER_MODEL}" "${prompt}" 2>&1; then
     echo "ERROR: OpenCode run failed"
     return 1
   fi

--- a/tools/bin/pi-adapter.sh
+++ b/tools/bin/pi-adapter.sh
@@ -80,7 +80,7 @@ adapter_run() {
   
   prompt="$(cat "${prompt_file}")"
   
-  if ! timeout "${timeout_seconds}" pi --model "${ADAPTER_MODEL}" "${prompt}" 2>&1; then
+  if ! adapter_run_with_timeout "${timeout_seconds}" pi --model "${ADAPTER_MODEL}" "${prompt}" 2>&1; then
     echo "ERROR: Pi run failed"
     return 1
   fi


### PR DESCRIPTION
## Summary
- `fix(reconcile)`: include `author` in `gh pr view --json` so `authorLogin` is populated; prevents reconcile from trying to self-approve own PRs (HTTP 422 stall).
- `fix(adapters)`: replace bare `timeout` (not on macOS PATH) with `adapter_run_with_timeout` fallback chain (gtimeout → timeout → python3 → perl); export `ACP_RESULT_FILE`, `ACP_RUN_DIR`, `ACP_SESSION` (+ `F_LOSNING_*` aliases) on adapter path so headless workers resolve real artifact paths.
- Fix `flow-runtime-doctor.sh` `${TIMEOUT_CMD}` unbound-var under `set -u`.

## Test plan
- [ ] Run reconcile against own open PR; verify no `event=APPROVE` HTTP 422
- [ ] Trigger PR-review worker on macOS without coreutils; verify no `timeout: command not found`
- [ ] `flow-runtime-doctor` runs clean under `set -u`
- [ ] Adapter-launched claude session writes to `<worktree>/.openclaw-artifacts/<session>/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)