### PR TITLE
chore(release): 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ layout for public releases.
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-04-27
+
+### Added
+- Fish shell completion script (Issue #109, #111)
+- ACP logo (light/dark SVG) in README (Issue #108, #112)
+- ACP worker usage examples in docs (Issue #110, #113)
+
+### Fixed
+- `reconcile`: include `author` in `gh pr view --json` so `authorLogin` populates; prevents self-approval HTTP 422 stall (#114)
+- Adapters: portable timeout via `adapter_run_with_timeout` fallback chain (gtimeout/timeout/python3/perl) — fixes `timeout: command not found` on macOS without coreutils (#114)
+- Adapters: export `ACP_RESULT_FILE`, `ACP_RUN_DIR`, `ACP_SESSION` (+ `F_LOSNING_*` aliases) on adapter path so headless workers resolve real artifact paths (#114)
+- `flow-runtime-doctor.sh`: `${TIMEOUT_CMD}` unbound under `set -u` (#114)
+
 ## [0.8.0] - 2026-04-26
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-control-plane",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Help a repo keep GitHub-driven coding agents running reliably without constant human babysitting",
   "homepage": "https://github.com/ducminhnguyen0319/agent-control-plane",
   "bugs": {


### PR DESCRIPTION
## Summary
Release v0.9.0. Bumps `package.json` version, fills CHANGELOG.

### Included since v0.8.0
- **feat**: fish shell completion (#111)
- **docs**: ACP logo light/dark SVGs (#112)
- **docs**: ACP worker usage examples (#113)
- **fix**: reconcile author detection + portable adapter timeout (#114)

## Test plan
- [x] `npm test` passes locally
- [x] tarball builds clean (248 kB / 102 files / v0.9.0)
- [ ] CI green
- [ ] After merge: tag `v0.9.0` + run `tools/scripts/automate-release.sh` to publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)