### PR TITLE
fix(scripts): release helper scripts resolved wrong repo root

### DIFF
--- a/tools/scripts/automate-release.sh
+++ b/tools/scripts/automate-release.sh
@@ -4,12 +4,12 @@ set -euo pipefail;
 # automate-release.sh - Automated release process
 # Usage: bash tools/scripts/automate-release.sh [--version <x.y.z>] [--no-publish]
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 PACKAGE_JSON="$SCRIPT_DIR/package.json"
 CHANGELOG="$SCRIPT_DIR/CHANGELOG.md"
 VERSION=""
-NO_PUBLISH=false"
-ERRORS=0;
+NO_PUBLISH=false
+ERRORS=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -18,7 +18,7 @@ while [[ $# -gt 0 ]]; do
       shift 2
       ;;
     --no-publish)
-      NO_PUBLISH=true"
+      NO_PUBLISH=true
       shift
       ;;
     *)

--- a/tools/scripts/security-scan.sh
+++ b/tools/scripts/security-scan.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # security-scan.sh - Security vulnerability scan
 # Usage: bash tools/scripts/security-scan.sh [--fix] [--json]
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 PACKAGE_JSON="$SCRIPT_DIR/package.json"
 FIX_MODE=false
 JSON_OUTPUT=false

--- a/tools/scripts/setup-ci.sh
+++ b/tools/scripts/setup-ci.sh
@@ -4,7 +4,7 @@ set -euo pipefail;
 # setup-ci.sh - Setup CI environment for ACP
 # Usage: bash tools/scripts/setup-ci.sh
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 echo "=== ACP CI Setup ==="
 echo ""

--- a/tools/scripts/verify-package.sh
+++ b/tools/scripts/verify-package.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # verify-package.sh - Verify npm package integrity
 # Usage: bash tools/scripts/verify-package.sh [--fix]
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 PACKAGE_JSON="$SCRIPT_DIR/package.json"
 ERRORS=0
 


### PR DESCRIPTION
## Summary
Release helper scripts under `tools/scripts/` were unusable.

### Bugs found
1. **Wrong `SCRIPT_DIR`** in 4 scripts — `cd "$(dirname …)/.."` from `tools/scripts/` resolves to `tools/`, not repo root. Every `$SCRIPT_DIR/package.json`, `$SCRIPT_DIR/CHANGELOG.md`, `cd "$SCRIPT_DIR"` failed.
2. **Stray quote** in `automate-release.sh`: `NO_PUBLISH=false"` and `NO_PUBLISH=true"` produced bash parse error (`syntax error near unexpected token \`;;'\`) once the dangling double-quote was closed by a later token.

### Why this matters now
Last two `Publish` workflow runs (`v0.7.1`, `v0.8.0`) failed at the `test-package-public-metadata.sh` step (exit 13: missing `publishConfig.provenance`). That root cause is already fixed on `main` (PR #112 added `provenance: true`). The remaining gap was the operator-side helper scripts that drive the tag/publish flow — fixed here.

### Fix
- `cd "…/.."` → `cd "…/../.."` in `automate-release.sh`, `verify-package.sh`, `security-scan.sh`, `setup-ci.sh`
- Remove stray `"` from `NO_PUBLISH` assignments

## Test plan
- [x] `bash -n` clean on all 4 scripts
- [x] `bash tools/scripts/verify-package.sh` runs to completion (PASS)
- [x] `bash tools/scripts/automate-release.sh --version 0.9.0 --no-publish` no longer errors at step 1
- [ ] CI green
- [ ] Next tag push triggers `Publish` workflow successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)